### PR TITLE
fixing typos

### DIFF
--- a/examples/cascade_train/cascade_train.go
+++ b/examples/cascade_train/cascade_train.go
@@ -15,7 +15,7 @@ func main() {
 
 	train_data := fann.ReadTrainFromFile("../../datasets/robot.train")
 
-	ann := fann.CreateStandart(num_layers, []uint32{train_data.GetNumInput(), num_neurons_hidden, train_data.GetNumOutput()})
+	ann := fann.CreateStandard(num_layers, []uint32{train_data.GetNumInput(), num_neurons_hidden, train_data.GetNumOutput()})
 
 	fmt.Println("Training network.")
 
@@ -31,7 +31,7 @@ func main() {
 	ann.ResetMSE()
 
 	var i uint32
-	for i = 0; i < test_data.Lenght(); i++ {
+	for i = 0; i < test_data.Length(); i++ {
 		ann.Test(test_data.GetInput(i), test_data.GetOutput(i))
 	}
 

--- a/examples/momentums/momentums.go
+++ b/examples/momentums/momentums.go
@@ -16,7 +16,7 @@ func main() {
 	for momentum = 0.0; momentum < 0.7; momentum += 0.1 {
 		fmt.Printf("============= momentum = %f =============\n", momentum)
 
-		ann := fann.CreateStandart(num_layers, []uint32{train_data.GetNumInput(), num_neurons_hidden, train_data.GetNumOutput()})
+		ann := fann.CreateStandard(num_layers, []uint32{train_data.GetNumInput(), num_neurons_hidden, train_data.GetNumOutput()})
 		ann.SetTrainingAlgorithm(fann.TRAIN_INCREMENTAL)
 		ann.SetLearningMomentum(momentum)
 		ann.TrainOnData(train_data, 2000, 500, desired_error)

--- a/examples/mushroom/mushroom.go
+++ b/examples/mushroom/mushroom.go
@@ -15,7 +15,7 @@ func main() {
 	fmt.Println("Creating network.")
 
 	trainData := fann.ReadTrainFromFile("datasets/mushroom.train")
-	ann := fann.CreateStandart(numLayers, []uint32{trainData.GetNumInput(), numNeuronsHidden, 1})
+	ann := fann.CreateStandard(numLayers, []uint32{trainData.GetNumInput(), numNeuronsHidden, 1})
 
 	fmt.Println("Training network.")
 	ann.SetActivationFunctionHidden(fann.SIGMOID_SYMMETRIC_STEPWISE)
@@ -30,7 +30,7 @@ func main() {
 	ann.ResetMSE()
 
 	var i uint32
-	for i = 0; i < testData.Lenght(); i++ {
+	for i = 0; i < testData.Length(); i++ {
 		ann.Test(testData.GetInput(i), testData.GetOutput(i))
 	}
 

--- a/examples/robot/robot.go
+++ b/examples/robot/robot.go
@@ -15,7 +15,7 @@ func main() {
 
 	train_data := fann.ReadTrainFromFile("../../datasets/robot.train")
 
-	ann := fann.CreateStandart(num_layers, []uint32{train_data.GetNumInput(), num_neurons_hidden, train_data.GetNumOutput()})
+	ann := fann.CreateStandard(num_layers, []uint32{train_data.GetNumInput(), num_neurons_hidden, train_data.GetNumOutput()})
 
 	fmt.Println("Training network.")
 
@@ -31,7 +31,7 @@ func main() {
 	ann.ResetMSE()
 
 	var i uint32
-	for i = 0; i < test_data.Lenght(); i++ {
+	for i = 0; i < test_data.Length(); i++ {
 		ann.Test(test_data.GetInput(i), test_data.GetOutput(i))
 	}
 

--- a/examples/simple_train/simple_train.go
+++ b/examples/simple_train/simple_train.go
@@ -10,7 +10,7 @@ func main() {
 	const maxEpochs = 500000
 	const epochsBetweenReports = 1000
 
-	ann := fann.CreateStandart(numLayers, []uint32{2, 3, 1})
+	ann := fann.CreateStandard(numLayers, []uint32{2, 3, 1})
 	ann.SetActivationFunctionHidden(fann.SIGMOID_SYMMETRIC)
 	ann.SetActivationFunctionOutput(fann.SIGMOID_SYMMETRIC)
 	ann.TrainOnFile("../../datasets/xor.data", maxEpochs, epochsBetweenReports, desiredError)

--- a/fann-train.go
+++ b/fann-train.go
@@ -62,7 +62,7 @@ func (ann *Ann) DescaleTrain(td *TrainData) ( ) {
 	C.fann_descale_train(ann.object, td.object)
 }
 
-func (td *TrainData) Lenght() (uint32) {
+func (td *TrainData) Length() (uint32) {
 	return uint32(C.fann_length_train_data(td.object))
 }
 

--- a/fann.go
+++ b/fann.go
@@ -34,7 +34,7 @@ type Ann struct {
 }
 
 //Create ann functions
-func CreateStandart(numLayers uint, layers []uint32) (*Ann) {
+func CreateStandard(numLayers uint, layers []uint32) (*Ann) {
 	var ann Ann
 	ann.object = C.fann_create_standard_array(C.uint(numLayers), (*C.uint)(&layers[0]))
 	return &ann


### PR DESCRIPTION
CreateStandart -> CreateStandard and TrainData.Lenght -> TrainData.Length, fixing issue #3

Hi!

I just fixed two typos, both in library and examples.

By the way, great binding.

Cheers, Philip
